### PR TITLE
[WIP] Enable sort function by creation time

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -58,6 +58,10 @@
               <%= form.radio_button "order_target", "last_modified_at", name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_at) %>
             </label>
+            <label>
+              <%= form.radio_button "order_target", "registered_at", name: "order_target" %>
+              <%= l(:label_full_text_search_order_target_registered_at) %>
+            </label>
           </p>
           <p>
             <label>
@@ -104,6 +108,12 @@
                              tag.i(class: "fas fa-clock") + " " +
                                l(:label_full_text_search_order_target_last_modified_at),
                              url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
+        </li>
+        <li>
+          <%= link_to_unless(@search_request.order_target == "registered_at",
+                             tag.i(class: "fas fa-clock") + " " +
+                               l(:label_full_text_search_order_target_registered_at),
+                             url_for(@search_request.to_params(order_target: "registered_at"))) %>
         </li>
       </ul>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,8 +55,8 @@
               <%= l(:label_full_text_search_order_target_score) %>
             </label>
             <label>
-              <%= form.radio_button "order_target", "date", name: "order_target" %>
-              <%= l(:label_full_text_search_order_target_date) %>
+              <%= form.radio_button "order_target", "last_modified_at", name: "order_target" %>
+              <%= l(:label_full_text_search_order_target_last_modified_at) %>
             </label>
           </p>
           <p>
@@ -100,10 +100,10 @@
                              url_for(@search_request.to_params(order_target: "score"))) %>
         </li>
         <li>
-          <%= link_to_unless(@search_request.order_target == "date",
+          <%= link_to_unless(@search_request.order_target == "last_modified_at",
                              tag.i(class: "fas fa-clock") + " " +
-                               l(:label_full_text_search_order_target_date),
-                             url_for(@search_request.to_params(order_target: "date"))) %>
+                               l(:label_full_text_search_order_target_last_modified_at),
+                             url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
         </li>
       </ul>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   label_full_text_search_result_order_type: Sort order
   label_full_text_search_order_target_score: score
   label_full_text_search_order_target_last_modified_at: updated at
+  label_full_text_search_order_target_registered_at: created at
   label_full_text_search_order_type_asc: asc
   label_full_text_search_order_type_desc: desc
   label_full_text_search_display_score: Display score

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
   label_full_text_search_result_order_target: Sort by
   label_full_text_search_result_order_type: Sort order
   label_full_text_search_order_target_score: score
-  label_full_text_search_order_target_date: updated at
+  label_full_text_search_order_target_last_modified_at: updated at
   label_full_text_search_order_type_asc: asc
   label_full_text_search_order_type_desc: desc
   label_full_text_search_display_score: Display score

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
   label_full_text_search_result_order_type: 並び順
   label_full_text_search_order_target_score: スコア
   label_full_text_search_order_target_last_modified_at: 更新日時
+  label_full_text_search_order_target_registered_at: 作成日時
   label_full_text_search_order_type_asc: 昇順
   label_full_text_search_order_type_desc: 降順
   label_full_text_search_display_score: スコアを表示

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,7 +4,7 @@ ja:
   label_full_text_search_result_order_target: 並び替え対象
   label_full_text_search_result_order_type: 並び順
   label_full_text_search_order_target_score: スコア
-  label_full_text_search_order_target_date: 更新日時
+  label_full_text_search_order_target_last_modified_at: 更新日時
   label_full_text_search_order_type_asc: 昇順
   label_full_text_search_order_type_desc: 降順
   label_full_text_search_display_score: スコアを表示

--- a/db/migrate/20231210061330_add_registered_at_to_fts_targets_with_index.rb
+++ b/db/migrate/20231210061330_add_registered_at_to_fts_targets_with_index.rb
@@ -97,7 +97,7 @@ class AddRegisteredAtToFtsTargetsWithIndex < ActiveRecord::Migration[5.2]
       subquery_for_created_on = type.where(type.arel_table[:id].eq(FtsTarget.arel_table[:source_id]))
                                     .select(:created_on)
                                     .to_sql
-      FtsTarget.where(source_type_id: FtsType.where(name: type.table_name.singularize.camelize).select(:id))
+      FtsTarget.where(source_type_id: FtsType.where(name: type.name.demodulize).select(:id))
                .update_all(registered_at: Arel.sql("(#{subquery_for_created_on})"))
     end
   end

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -242,7 +242,7 @@ module FullTextSearch
         direction = ""
       end
       case @request.order_target
-      when "date"
+      when "last_modified_at"
         [
           "#{direction}last_modified_at",
         ]

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -226,6 +226,7 @@ module FullTextSearch
         "content_snippets",
         "id",
         "last_modified_at",
+        "registered_at",
         "project_id",
         "source_id",
         "source_type_id",
@@ -245,6 +246,10 @@ module FullTextSearch
       when "last_modified_at"
         [
           "#{direction}last_modified_at",
+        ]
+      when "registered_at"
+        [
+          "#{direction}registered_at",
         ]
       else
         # TODO: -_score is useful?
@@ -302,6 +307,7 @@ module FullTextSearch
         # Rails.logger.debug(title: record["title_digest"],
         #                    description: record["description_digest"])
         record["last_modified_at"] += Target.time_offset
+        record["registered_at"] += Target.time_offset
         record["highlighted_title"] = record["highlighted_title"].html_safe
         record["content_snippets"] = record["content_snippets"].collect do |snippet|
           snippet.html_safe

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -290,6 +290,12 @@ module FullTextSearch
                                                        "order_type" => "desc"),
                          ],
                          [
+                           "created at",
+                           expected_search_path,
+                           common_search_options.merge("order_target" => "registered_at",
+                                                       "order_type" => "desc"),
+                         ],
+                         [
                            "asc",
                            expected_search_path,
                            common_search_options.merge("order_target" => "score",

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -286,7 +286,7 @@ module FullTextSearch
                          [
                            "updated at",
                            expected_search_path,
-                           common_search_options.merge("order_target" => "date",
+                           common_search_options.merge("order_target" => "last_modified_at",
                                                        "order_type" => "desc"),
                          ],
                          [


### PR DESCRIPTION
Related Issue: https://github.com/clear-code/redmine_full_text_search/issues/115
Related PR: https://github.com/clear-code/redmine_full_text_search/pull/118

## What I did
- Added sort function by creation time 
    - User can sort each item by creation time on the search page.
        - ref: http://localhost:3000/search 

| Before | After |
| --- | --- |
| <img width=100% alt="Screenshot 2023-12-20 at 20 29 57" src="https://github.com/otegami/redmine_full_text_search/assets/45173523/4817d596-e7fe-4336-b356-df5c2550ae21"> | <img width=100% alt="Screenshot 2023-12-20 at 20 29 37" src="https://github.com/otegami/redmine_full_text_search/assets/45173523/6ca0d672-c2c8-4194-bdeb-feda816843ea"> |